### PR TITLE
Fixed deprecation warning when formatting dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+    - "5"
+    - "6"
+    - "4"
+install:
+    - npm install
+script:
+    - npm run test
+branches:
+    only:
+      - master
+      - development

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -24,8 +24,7 @@ module.exports = function restfulFormatters(tables, req, res, errorHandler){
         },
         date: function(str){
             if(str===null && typeof str==='undefined') str='';
-            str = $sanitize.trim(str);
-            if(str!=='') str = Date.parse(str);
+            if(str!=='') str = Date.parse($sanitize.trim(str+''));
             return str;
         },
         float: function(str){

--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
     "name": "Jason Futch",
     "email": "jasonfutch@gmail.com"
   },
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jasonfutch/restfulize"
+  "bugs": {
+    "url": "https://github.com/jasonfutch/restfulize/issues"
   },
   "dependencies": {
     "async": "^1.5.2",
@@ -28,14 +26,17 @@
   "engines": {
     "node": ">= 0.8"
   },
-  "bugs": {
-    "url": "https://github.com/jasonfutch/restfulize/issues"
-  },
   "homepage": "https://github.com/jasonfutch/restfulize",
+  "license": "MIT",
+  "main": "./index.js",
   "maintainers": [
     {
       "name": "jasonfutch",
       "email": "jasonfutch@gmail.com"
     }
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jasonfutch/restfulize"
+  }
 }


### PR DESCRIPTION
This PR removes the warning `$sanitize` issues when using method `trim` and passing an `Object` as parameter by simply using implicit conversion. 
- Ideal is to use **explicit conversion** but project already uses this format

Fixes https://github.com/jasonfutch/restfulize/issues/1
